### PR TITLE
Set peer dependency of tns-core-modules to ^3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "tns-platform-declarations": "^3.0.0"
   },
   "peerDependencies": {
-    "tns-core-modules": "3.0.0"
+    "tns-core-modules": "^3.0.0"
   },
   "bugs": {
     "url": "https://github.com/triniwiz/nativescript-twitter/issues"


### PR DESCRIPTION
I get the following message while `"tns-core-modules": "^3.3.0"` is defined in package.json. 

```
npm WARN nativescript-twitter@2.0.0 requires a peer of tns-core-modules@3.0.0 but none is installed. You must install peer dependencies yourself.
```